### PR TITLE
fix: pass temporary references properly

### DIFF
--- a/apps/web/src/framework/entry.rsc.tsx
+++ b/apps/web/src/framework/entry.rsc.tsx
@@ -48,7 +48,10 @@ export default async function handler(request: Request): Promise<Response> {
 		}
 	}
 
-	const rscStream = renderToReadableStream<RscPayload>({ formState, returnValue, root: <Root /> });
+	const rscStream = renderToReadableStream<RscPayload>(
+		{ formState, returnValue, root: <Root /> },
+		{ temporaryReferences },
+	);
 
 	const isRscRequest = !request.headers.get("accept")?.includes("text/html");
 


### PR DESCRIPTION
According to: https://github.com/vitejs/vite-plugin-react/pull/603